### PR TITLE
fix: use Kotlin DSL in app build script

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,40 +4,43 @@ plugins {
 }
 
 android {
-    namespace "com.example.cokewidget"
-    compileSdk 34
+    namespace = "com.example.cokewidget"
+    compileSdk = 34
 
     defaultConfig {
-        applicationId "com.example.cokewidget"
-        minSdk 26
-        targetSdk 34
-        versionCode 1
-        versionName "1.0"
+        applicationId = "com.example.cokewidget"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
 
-        vectorDrawables { useSupportLibrary true }
+        vectorDrawables { useSupportLibrary = true }
     }
 
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
         debug {
-            debuggable true
+            isDebuggable = true
         }
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions { jvmTarget = "17" }
 }
 
 dependencies {
-    implementation "androidx.preference:preference-ktx:1.2.1"
-    implementation "androidx.core:core-ktx:1.13.1"
-    implementation "androidx.appcompat:appcompat:1.7.0"
-    implementation "com.google.android.material:material:1.12.0"
-    implementation "androidx.work:work-runtime-ktx:2.9.1"
+    implementation("androidx.preference:preference-ktx:1.2.1")
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.appcompat:appcompat:1.7.0")
+    implementation("com.google.android.material:material:1.12.0")
+    implementation("androidx.work:work-runtime-ktx:2.9.1")
 }


### PR DESCRIPTION
## Summary
- refactor app build script to use Kotlin DSL property assignments

## Testing
- `gradle assembleDebug` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_6898450d847c832391137a37c3b60bdd